### PR TITLE
Replaced buttons to link

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@types/node": "^18.7.14",
     "classnames": "^2.3.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.4.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ specifiers:
   gh-pages: ^4.0.0
   react: ^18.2.0
   react-dom: ^18.2.0
+  react-router-dom: ^6.4.2
   typescript: ^4.6.4
   vite: ^3.0.7
 
@@ -17,6 +18,7 @@ dependencies:
   classnames: 2.3.1
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
+  react-router-dom: 6.4.2_biqbaboplfbrettd7655fr4n2y
 
 devDependencies:
   '@types/react': 18.0.18
@@ -341,6 +343,11 @@ packages:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
+
+  /@remix-run/router/1.0.2:
+    resolution: {integrity: sha512-GRSOFhJzjGN+d4sKHTMSvNeUPoZiDHWmRnXfzaxrqe7dE/Nzlc8BiMSJdLDESZlndM7jIUrZ/F4yWqVYlI0rwQ==}
+    engines: {node: '>=14'}
+    dev: false
 
   /@types/node/18.7.14:
     resolution: {integrity: sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==}
@@ -1024,6 +1031,29 @@ packages:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /react-router-dom/6.4.2_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-yM1kjoTkpfjgczPrcyWrp+OuQMyB1WleICiiGfstnQYo/S8hPEEnVjr/RdmlH6yKK4Tnj1UGXFSa7uwAtmDoLQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.0.2
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-router: 6.4.2_react@18.2.0
+    dev: false
+
+  /react-router/6.4.2_react@18.2.0:
+    resolution: {integrity: sha512-Rb0BAX9KHhVzT1OKhMvCDMw776aTYM0DtkxqUBP8dNBom3mPXlfNs76JNGK8wKJ1IZEY1+WGj+cvZxHVk/GiKw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.0.2
+      react: 18.2.0
+    dev: false
 
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,11 +1,19 @@
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { AuthForm } from "src/features";
 
-import styles from './App.module.css';
+import styles from "./App.module.css";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <AuthForm />,
+  },
+]);
 
 export const App = () => {
   return (
     <div className={styles.app}>
-      <AuthForm />
+      <RouterProvider router={router} />
     </div>
   );
 };

--- a/src/features/Auth/ui/AuthForm.tsx
+++ b/src/features/Auth/ui/AuthForm.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-
+import { useSearchParams } from "react-router-dom";
 import { LogIn } from "./LogIn";
 import { SignUp } from "./SignUp";
 
@@ -8,17 +7,21 @@ import { RestorePassword } from "./RestorePassword";
 
 type Props = {};
 const forms = {
-  logIn: LogIn,
-  signUp: SignUp,
-  restorePassword: RestorePassword,
+  "log-in": LogIn,
+  "sign-up": SignUp,
+  "restore-password": RestorePassword,
 } as const;
 
+type FormKeys = keyof typeof forms;
+
 export const AuthForm = ({}: Props) => {
-  const [currentForm, setCurrentForm] = useState<keyof typeof forms>("logIn");
+  const [searchParams] = useSearchParams();
+  const currentForm = (searchParams.get("form") as FormKeys) ?? "log-in";
   const Form = forms[currentForm];
+
   return (
     <div className={styles.authForm}>
-      <Form onFormChange={(form) => setCurrentForm(form)} />
+      <Form />
     </div>
   );
 };

--- a/src/features/Auth/ui/LogIn.tsx
+++ b/src/features/Auth/ui/LogIn.tsx
@@ -14,11 +14,7 @@ import { useLogin } from "../model/useLogin";
 
 import styles from "./Login.module.css";
 
-type LogInProps = {
-  onFormChange: (newForm: "signUp" | "restorePassword") => void;
-};
-
-export const LogIn = ({ onFormChange }: LogInProps) => {
+export const LogIn = () => {
   const [isAgreementChecked, setIsAgreementChecked] = useState(true);
   const [emailValue, setEmailValue] = useState("");
   const [passwordValue, setPasswordValue] = useState("");
@@ -83,13 +79,11 @@ export const LogIn = ({ onFormChange }: LogInProps) => {
         </Button>
       </form>
       <div className={styles.forgotPassword}>
-        <Link onClick={() => onFormChange("restorePassword")}>
-          Forgot password?
-        </Link>
+        <Link to="/?form=restore-password">Forgot password?</Link>
       </div>
       <div className={styles.footer}>
         <span className={styles.footerText}>Have no account yet?</span>
-        <Link onClick={() => onFormChange("signUp")}>Sign up</Link>
+        <Link to="/?form=sign-up">Sign up</Link>
       </div>
     </div>
   );

--- a/src/features/Auth/ui/RestorePassword.tsx
+++ b/src/features/Auth/ui/RestorePassword.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { UnhandledError, UserDoesNotExistError } from "src/shared/errors";
 import { Button } from "src/shared/ui/Button";
 import { ErrorText } from "src/shared/ui/ErrorText";
@@ -10,11 +10,7 @@ import { useRestorePassword } from "../model/useRestorePassword";
 
 import styles from "./RestorePassword.module.css";
 
-type Props = {
-  onFormChange: (newForm: "logIn") => void;
-};
-
-export const RestorePassword = ({ onFormChange }: Props) => {
+export const RestorePassword = () => {
   const [emailValue, setEmailValue] = useState("");
   const [error, setError] = useState("");
   const { restorePassword, isLoading } = useRestorePassword();
@@ -49,14 +45,14 @@ export const RestorePassword = ({ onFormChange }: Props) => {
           isError={Boolean(error)}
           onFocus={() => setError("")}
         />
-        <ErrorText text={error} className={styles.errorText}/>
+        <ErrorText text={error} className={styles.errorText} />
         <Button className={styles.submitButton} type="submit">
           Send email
         </Button>
       </form>
       <div className={styles.footer}>
         <span className={styles.footerText}>Return to</span>
-        <Link onClick={() => onFormChange("logIn")}>log in</Link>
+        <Link to="/?form=log-in">log in</Link>
       </div>
     </div>
   );

--- a/src/features/Auth/ui/SignUp.tsx
+++ b/src/features/Auth/ui/SignUp.tsx
@@ -10,11 +10,7 @@ import { useSignUp } from "../model/useRegister";
 
 import styles from "./SignUp.module.css";
 
-type SignUpProps = {
-  onFormChange: (newForm: "logIn") => void;
-};
-
-export const SignUp = ({ onFormChange }: SignUpProps) => {
+export const SignUp = () => {
   const [isAgreementChecked, setIsAgreementChecked] = useState(true);
   const [emailValue, setEmailValue] = useState("");
   const [passwordValue, setPasswordValue] = useState("");
@@ -115,7 +111,7 @@ export const SignUp = ({ onFormChange }: SignUpProps) => {
       </form>
       <div className={styles.footer}>
         <span className={styles.footerText}>Already registered?</span>
-        <Link onClick={() => onFormChange("logIn")}>Log in</Link>
+        <Link to="/?form=log-in">Log in</Link>
       </div>
     </div>
   );

--- a/src/shared/ui/Link/Link.tsx
+++ b/src/shared/ui/Link/Link.tsx
@@ -1,10 +1,10 @@
 import {
   ButtonHTMLAttributes,
-  HTMLAttributes,
   ReactNode,
   SyntheticEvent,
 } from "react";
 import cls from "classnames";
+import { Link as RouterLink } from "react-router-dom";
 
 import styles from "./Link.module.css";
 
@@ -14,9 +14,21 @@ type Props = {
   onClick?: (e: SyntheticEvent) => void;
   type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
   href?: string;
+  to?: string;
 };
 
-export const Link = ({ type, children, className, onClick, href }: Props) => {
+export const Link = ({
+  type,
+  children,
+  className,
+  onClick,
+  href,
+  to,
+}: Props) => {
+  if (to) {
+    return <RouterLink to={to}>{children}</RouterLink>;
+  }
+
   if (onClick && !href) {
     return (
       <button
@@ -28,6 +40,7 @@ export const Link = ({ type, children, className, onClick, href }: Props) => {
       </button>
     );
   }
+
   return (
     <a
       // I don't know why, but it's not focusing with tab without it (chrome, mac os) :)


### PR DESCRIPTION
I've replaced buttons to links and added current form state in URL
Reasons why it's better than previous version:

1. Now it's possible to use back/forward buttons
2. If user have any troubles with auth, your customer support can send them direct link to the form they need. For example if user forgot their password, customer support will send them link like `domain.com/auth?form=restore-password`